### PR TITLE
Fixed caused validation to always succeed due to missing "await".

### DIFF
--- a/src/lambda/inboundMessageHandler/index.js
+++ b/src/lambda/inboundMessageHandler/index.js
@@ -27,7 +27,7 @@ const processDigitalChannelRequest = async (event) => {
   switch (event.rawPath) {
     case '/webhook/facebook':
       log.debug('Facebook channel detected.');
-      const validRequest = fb.validateRequest(event);
+      const validRequest = await fb.validateRequest(event);
 
       if (!validRequest) {
         log.warn('Invalid payload signature');


### PR DESCRIPTION
* Issue #5

* Description of changes:
    - Added "await" to receive the result of the payload signature judgment process.
