### PR TITLE
Add new Contact Attribute containing the initial message sent,

### DIFF
--- a/src/lambda/inboundMessageHandler/lib/handlers/sms.js
+++ b/src/lambda/inboundMessageHandler/lib/handlers/sms.js
@@ -8,7 +8,8 @@ const handler = async (messageString) => {
   const message = JSON.parse(messageString);
   const participant = await inboundHelper.getOrCreateParticipant(
     CHANNEL_TYPE,
-    getVendorId(message)
+    getVendorId(message),
+    message
   );
 
   await inboundHelper.sendMessage(participant, message.messageBody);

--- a/src/lambda/inboundMessageHandler/lib/handlers/sms.js
+++ b/src/lambda/inboundMessageHandler/lib/handlers/sms.js
@@ -9,7 +9,7 @@ const handler = async (messageString) => {
   const participant = await inboundHelper.getOrCreateParticipant(
     CHANNEL_TYPE,
     getVendorId(message),
-    message
+    message.messageBody.trim().toLowerCase()
   );
 
   await inboundHelper.sendMessage(participant, message.messageBody);

--- a/src/lambda/inboundMessageHandler/lib/inboundHelper.js
+++ b/src/lambda/inboundMessageHandler/lib/inboundHelper.js
@@ -62,7 +62,7 @@ const getOrCreateParticipant = async (channel, vendorId, message) => {
     channel,
     vendorId,
     existingParticipant,
-	message
+    message
   );
   log.debug('finished creating participant', { channel, vendorId });
 
@@ -164,7 +164,7 @@ const addNewParticipant = async (channel, vendorId, existingParticipant, message
     Attributes: {
       chatframework_Channel: channel,
       chatframework_VendorId: vendorId,
-	  chatframework_InitialMessage: message,
+      chatframework_InitialMessage: message,
     },
   };
 

--- a/src/lambda/inboundMessageHandler/lib/inboundHelper.js
+++ b/src/lambda/inboundMessageHandler/lib/inboundHelper.js
@@ -34,7 +34,7 @@ const channelSNSTopicMap = {
 const getOrCreateParticipant = async (channel, vendorId, messageBody) => {
   const existingParticipant = await checkForExistingParticipant(
     channel,
-    vendorId,
+    vendorId
   );
 
   // Condition to check 1/ there is an existing chat AND 2/ The chat has not completed (indicated by no S3 transcript) AND 3/ Chat is less than 24 hours old

--- a/src/lambda/inboundMessageHandler/lib/inboundHelper.js
+++ b/src/lambda/inboundMessageHandler/lib/inboundHelper.js
@@ -31,7 +31,7 @@ const channelSNSTopicMap = {
 ////////////////////
 // Public Methods //
 ////////////////////
-const getOrCreateParticipant = async (channel, vendorId, message) => {
+const getOrCreateParticipant = async (channel, vendorId, messageBody) => {
   const existingParticipant = await checkForExistingParticipant(
     channel,
     vendorId,
@@ -62,7 +62,7 @@ const getOrCreateParticipant = async (channel, vendorId, message) => {
     channel,
     vendorId,
     existingParticipant,
-    message
+    messageBody
   );
   log.debug('finished creating participant', { channel, vendorId });
 
@@ -154,7 +154,7 @@ const checkForExistingParticipant = async (channel, vendorId) => {
   return result.Items[0];
 };
 
-const addNewParticipant = async (channel, vendorId, existingParticipant, message) => {
+const addNewParticipant = async (channel, vendorId, existingParticipant, messageBody) => {
   const params = {
     ContactFlowId: CONTACT_FLOW_ID,
     InstanceId: getConnectInstanceId(AMAZON_CONNECT_ARN),
@@ -164,7 +164,7 @@ const addNewParticipant = async (channel, vendorId, existingParticipant, message
     Attributes: {
       chatframework_Channel: channel,
       chatframework_VendorId: vendorId,
-      chatframework_InitialMessage: message,
+      chatframework_InitialMessage: messageBody,
     },
   };
 

--- a/src/lambda/inboundMessageHandler/lib/inboundHelper.js
+++ b/src/lambda/inboundMessageHandler/lib/inboundHelper.js
@@ -31,10 +31,10 @@ const channelSNSTopicMap = {
 ////////////////////
 // Public Methods //
 ////////////////////
-const getOrCreateParticipant = async (channel, vendorId) => {
+const getOrCreateParticipant = async (channel, vendorId, message) => {
   const existingParticipant = await checkForExistingParticipant(
     channel,
-    vendorId
+    vendorId,
   );
 
   // Condition to check 1/ there is an existing chat AND 2/ The chat has not completed (indicated by no S3 transcript) AND 3/ Chat is less than 24 hours old
@@ -61,7 +61,8 @@ const getOrCreateParticipant = async (channel, vendorId) => {
   const participant = await addNewParticipant(
     channel,
     vendorId,
-    existingParticipant
+    existingParticipant,
+	message
   );
   log.debug('finished creating participant', { channel, vendorId });
 
@@ -153,7 +154,7 @@ const checkForExistingParticipant = async (channel, vendorId) => {
   return result.Items[0];
 };
 
-const addNewParticipant = async (channel, vendorId, existingParticipant) => {
+const addNewParticipant = async (channel, vendorId, existingParticipant, message) => {
   const params = {
     ContactFlowId: CONTACT_FLOW_ID,
     InstanceId: getConnectInstanceId(AMAZON_CONNECT_ARN),
@@ -163,6 +164,7 @@ const addNewParticipant = async (channel, vendorId, existingParticipant) => {
     Attributes: {
       chatframework_Channel: channel,
       chatframework_VendorId: vendorId,
+	  chatframework_InitialMessage: message,
     },
   };
 


### PR DESCRIPTION
I have modified sms.js to send the body (trim and toLower)  of the text message to inboundhelper.js. 
In inboundhelper.js I create a new contact attribute containing this message. This allows a customer to branch on the initial message sent to the solution. If a customer sends a text message with "Out" as the message, we can branch on the contents of the new attribute "chatframework_InitialMessage" to log an outage for the customer with the phone number in  question (chatframework_VendorId).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
