### PR TITLE
Fixes AWS-CDK v1.135.0 compatibility issues

### DIFF
--- a/lib/chat-message-streaming-examples-stack.ts
+++ b/lib/chat-message-streaming-examples-stack.ts
@@ -284,8 +284,8 @@ export class ChatMessageStreamingExamplesStack extends cdk.Stack {
 
     // health check Lambda
     let healthCheckFunction: lambda.Function;
-    let digitalChannelMessageIntegration: apigw2i.LambdaProxyIntegration;
-    let digitalChannelHealthCheckIntegration: apigw2i.LambdaProxyIntegration;
+    let digitalChannelMessageIntegration: apigw2i.HttpLambdaIntegration;
+    let digitalChannelHealthCheckIntegration: apigw2i.HttpLambdaIntegration;
     let digitalChannelApi;
 
     if(enableFB){
@@ -313,13 +313,12 @@ export class ChatMessageStreamingExamplesStack extends cdk.Stack {
         })
       );
       // inbound API Gateway (digital channel)
-      digitalChannelMessageIntegration = new apigw2i.LambdaProxyIntegration({
-        handler: inboundMessageFunction,
-      });
-
-      digitalChannelHealthCheckIntegration = new apigw2i.LambdaProxyIntegration({
-        handler: healthCheckFunction,
-      });
+      digitalChannelMessageIntegration = new apigw2i.HttpLambdaIntegration(
+        'inboundMessageFunction', inboundMessageFunction);
+      
+      // digitalChannelHealthCheckIntegration = new apigw2i.HttpLambdaIntegration({
+      digitalChannelHealthCheckIntegration = new apigw2i.HttpLambdaIntegration(
+        'healthCheckFunction', healthCheckFunction);
 
       digitalChannelApi = new apigw2.HttpApi(this, 'digitalChannelApi', {
         corsPreflight: {

--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.121.0",
-    "@aws-cdk/aws-apigatewayv2": "^1.121.0",
-    "@aws-cdk/aws-apigatewayv2-integrations": "^1.121.0",
-    "@aws-cdk/aws-dynamodb": "^1.121.0",
-    "@aws-cdk/aws-iam": "^1.121.0",
-    "@aws-cdk/aws-lambda": "^1.121.0",
-    "@aws-cdk/aws-pinpoint": "^1.121.0",
-    "@aws-cdk/aws-s3": "^1.121.0",
-    "@aws-cdk/aws-s3-notifications": "^1.121.0",
-    "@aws-cdk/aws-secretsmanager": "^1.121.0",
-    "@aws-cdk/aws-sns": "^1.121.0",
-    "@aws-cdk/aws-sns-subscriptions": "^1.121.0",
-    "@aws-cdk/core": "^1.121.0",
+    "@aws-cdk/aws-apigateway": "1.135.0",
+    "@aws-cdk/aws-apigatewayv2": "1.135.0",
+    "@aws-cdk/aws-apigatewayv2-integrations": "1.135.0",
+    "@aws-cdk/aws-dynamodb": "1.135.0",
+    "@aws-cdk/aws-iam": "1.135.0",
+    "@aws-cdk/aws-lambda": "1.135.0",
+    "@aws-cdk/aws-pinpoint": "1.135.0",
+    "@aws-cdk/aws-s3": "1.135.0",
+    "@aws-cdk/aws-s3-notifications": "1.135.0",
+    "@aws-cdk/aws-secretsmanager": "1.135.0",
+    "@aws-cdk/aws-sns": "1.135.0",
+    "@aws-cdk/aws-sns-subscriptions": "1.135.0",
+    "@aws-cdk/core": "1.135.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-connect/amazon-connect-message-streaming-examples/issues/14
Resolves #14 

*Description of changes:* 

- LambdaProxyIntegration is replaced with HttpLambdaIntegration and the parameters have been updated for the new API in /lib/chat-message-streaming-examples-stack.ts
- The package.json references to the AWS CDK are now fixed to v1.135.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
